### PR TITLE
Inform that DB must be configured in UI.

### DIFF
--- a/notebooks/ConfigureOpenScale.ipynb
+++ b/notebooks/ConfigureOpenScale.ipynb
@@ -568,8 +568,7 @@
     "    data_mart_details = ai_client.data_mart.get_details()\n",
     "    print('Using existing external datamart')\n",
     "except:\n",
-    "    print('Setting up external datamart')\n",
-    "    ai_client.data_mart.setup(db_credentials=DATABASE_CREDENTIALS, schema=SCHEMA_NAME)"
+    "    print('Datamart must be configured in ICP4D OpenScale. See https://cloud.ibm.com/docs/services/ai-openscale-icp?topic=ai-openscale-icp-gs-get-started')\n"
    ]
   },
   {


### PR DESCRIPTION
Formerly, the notebook allowed the user to configure the datamart
(DB) in the notebook, by inserting DB credentials and schema.
We'll require the user to use the OpenScale GUI, which is well
documented and should be less confusing.